### PR TITLE
Disallow adding filenodes in other phases than build

### DIFF
--- a/analyzerservice.proto
+++ b/analyzerservice.proto
@@ -21,11 +21,6 @@ message InfoNodeMessage {
     InfoNode infonode = 3;
 }
 
-message FileNodeMessage {
-    int64 token = 1;
-    FileNode filenode = 2;
-}
-
 message PackageNodeMessage {
     int64 token = 1;
     PackageNode packagenode = 2;
@@ -43,7 +38,6 @@ message SendResponse {
 service AnalysisService {
     rpc GetAnalyzerConfig(AnalyzerConfigRequest) returns (AnalyzerConfigResponse) {}
     rpc SendInfoNodes(stream InfoNodeMessage) returns (SendResponse) {}
-    rpc SendFileNode(stream FileNodeMessage) returns (SendResponse) {}
     rpc SendPackageNode(stream PackageNodeMessage) returns (SendResponse) {}
     rpc SendDiagnosticNode(stream DiagnosticNodeMessage) returns (SendResponse) {}
 }


### PR DESCRIPTION
We must not be able to add filenodes to the graph after build phase.